### PR TITLE
add more test coverage to the schemas generated through unit tests

### DIFF
--- a/code-generator/FileGenerator.ts
+++ b/code-generator/FileGenerator.ts
@@ -1236,7 +1236,7 @@ export default class FileGenerator extends CodeStream {
   #generateResolvedTypeMetadata(resolvedType: ResolvedType) {
     if ('generic' in resolvedType) {
       this.write('type: "generic",\n');
-      this.write(`value: "${resolvedType.generic}"`);
+      this.write(`value: "${resolvedType.generic}"\n`);
     } else if ('template' in resolvedType) {
       this.write('type: "template",\n');
       this.write(`name: "${resolvedType.template}",\n`);
@@ -1274,20 +1274,27 @@ export default class FileGenerator extends CodeStream {
             ']\n'
           );
           break;
-        case 'map':
-          for (const [name, value] of new Map([
+        case 'map': {
+          const items = [
             ['key', resolvedType.key],
             ['value', resolvedType.value],
-          ])) {
+          ] as const;
+          for (const item of items) {
+            const [name, value] = item;
             this.write(
               `${name}: {\n`,
               () => {
                 this.#generateResolvedTypeMetadata(value.resolved);
               },
-              '},\n'
+              '}'
             );
+            if (item !== items[items.length - 1]) {
+              this.append(',');
+            }
+            this.append('\n');
           }
           break;
+        }
       }
     } else if ('fileGenerator' in resolvedType) {
       this.write(`name: "${resolvedType.identifier}",\n`);
@@ -1324,7 +1331,6 @@ export default class FileGenerator extends CodeStream {
       this.write(`kind: "${kind}",\n`);
       this.write(`name: "${resolvedType.name.value}"\n`);
     }
-    this.append(',\n');
   }
   #generateNodeCode(node: ASTGeneratorOutputNode) {
     switch (node.type) {

--- a/code-generator/FileGenerator.ts
+++ b/code-generator/FileGenerator.ts
@@ -1204,6 +1204,7 @@ export default class FileGenerator extends CodeStream {
       `export const ${node.name.value}Metadata = {\n`,
       () => {
         this.write(`name: "${node.name.value}",\n`);
+        this.write(`id: ${this.#getUniqueHeader(node)},\n`);
         this.write(
           'params: [\n',
           () => {
@@ -1297,8 +1298,17 @@ export default class FileGenerator extends CodeStream {
         }
       }
     } else if ('fileGenerator' in resolvedType) {
+      const definition = this.#resolvedTypeExpressionToDefinition(resolvedType);
       this.write(`name: "${resolvedType.identifier}",\n`);
+      this.write(
+        `id: "${resolvedType.fileGenerator.#getUniqueHeader(definition)}",\n`
+      );
       this.write('type: "externalType",\n');
+      this.write(
+        `externalModule: ${
+          resolvedType.fileGenerator.#externalModule ? 'true' : 'false'
+        },\n`
+      );
       this.write(
         `relativePath: "${resolvedType.fileGenerator.#sourceImportToOutDirImport(
           this,
@@ -1306,6 +1316,7 @@ export default class FileGenerator extends CodeStream {
         )}"\n`
       );
     } else {
+      this.write(`id: ${this.#getUniqueHeader(resolvedType)},\n`);
       this.write('type: "internalType",\n');
       let kind: string;
       switch (resolvedType.type) {

--- a/code-generator/FileGenerator.ts
+++ b/code-generator/FileGenerator.ts
@@ -1240,69 +1240,55 @@ export default class FileGenerator extends CodeStream {
     } else if ('template' in resolvedType) {
       this.write('type: "template",\n');
       this.write(`name: "${resolvedType.template}",\n`);
-      this.write(
-        'params: [\n',
-        () => {
+      switch (resolvedType.template) {
+        default:
+          throw new Exception(
+            // @ts-expect-error `template` property should not exist since we have tried all template types
+            `Failed to generate metadata for template: ${resolvedType.template}`
+          );
+        case 'optional':
+        case 'set':
+        case 'vector':
           this.write(
-            '{\n',
+            'value: {\n',
             () => {
-              switch (resolvedType.template) {
-                default:
-                  throw new Exception(
-                    // @ts-expect-error `template` property should not exist since we have tried all template types
-                    `Failed to generate metadata for template: ${resolvedType.template}`
-                  );
-                case 'optional':
-                case 'set':
-                case 'vector':
-                  this.write(
-                    'value: {\n',
-                    () => {
-                      this.#generateResolvedTypeMetadata(resolvedType.type);
-                    },
-                    '}\n'
-                  );
-                  break;
-                case 'tuple':
-                  this.write(
-                    'args: [\n',
-                    () => {
-                      for (const resolvedTupleType of resolvedType.types) {
-                        this.write(
-                          '{\n',
-                          () => {
-                            this.#generateResolvedTypeMetadata(
-                              resolvedTupleType
-                            );
-                          },
-                          '},\n'
-                        );
-                      }
-                    },
-                    ']\n'
-                  );
-                  break;
-                case 'map':
-                  for (const [name, value] of new Map([
-                    ['key', resolvedType.key],
-                    ['value', resolvedType.value],
-                  ])) {
-                    this.write(
-                      `${name}: {\n`,
-                      () => {
-                        this.#generateResolvedTypeMetadata(value.resolved);
-                      },
-                      '},\n'
-                    );
-                  }
-                  break;
-              }
+              this.#generateResolvedTypeMetadata(resolvedType.type);
             },
             '}\n'
           );
-        },
-        ']\n'
-      );
+          break;
+        case 'tuple':
+          this.write(
+            'args: [\n',
+            () => {
+              for (const resolvedTupleType of resolvedType.types) {
+                this.write(
+                  '{\n',
+                  () => {
+                    this.#generateResolvedTypeMetadata(resolvedTupleType);
+                  },
+                  '},\n'
+                );
+              }
+            },
+            ']\n'
+          );
+          break;
+        case 'map':
+          for (const [name, value] of new Map([
+            ['key', resolvedType.key],
+            ['value', resolvedType.value],
+          ])) {
+            this.write(
+              `${name}: {\n`,
+              () => {
+                this.#generateResolvedTypeMetadata(value.resolved);
+              },
+              '},\n'
+            );
+          }
+          break;
+      }
     } else if ('fileGenerator' in resolvedType) {
       this.write(`name: "${resolvedType.identifier}",\n`);
       this.write('type: "externalType",\n');

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -5,6 +5,7 @@ import * as glob from 'glob';
 import { FileGenerator } from '../code-generator';
 import { spawn } from 'child-process-utilities';
 import CodeStream from 'textstreamjs';
+import assert from 'assert';
 
 type FunctionPrefix = 'default' | 'update' | 'compare' | 'encode' | 'decode';
 
@@ -85,7 +86,29 @@ function generateTestSchemaFilesCode({
     '}\n'
   );
   cs.write(
-    'function randomValuesFromParamMetadataType(paramType, typeModuleResult) {\n',
+    'function resolveRelativeImport(importPath, paramType) {\n',
+    () => {
+      cs.write('if(paramType.externalModule) return paramType.relativePath;\n');
+      cs.write('const baseImportDir = path.dirname(importPath);\n');
+      cs.write(
+        'const absoluteImportPath = path.resolve(baseImportDir, paramType.relativePath);\n'
+      );
+      cs.write(
+        `let finalRelativePath = path.relative("${rootDir}", absoluteImportPath);`
+      );
+      cs.write(
+        'if(!finalRelativePath.startsWith(".") && !finalRelativePath.startsWith("/")) {\n',
+        () => {
+          cs.write('finalRelativePath = `./${finalRelativePath}`;');
+        },
+        '}\n'
+      );
+      cs.write('return finalRelativePath;\n');
+    },
+    '}\n'
+  );
+  cs.write(
+    'function randomValuesFromParamMetadataType(importPath, paramType, typeModuleResult) {\n',
     () => {
       cs.write('let testValue;\n');
       cs.write(
@@ -96,19 +119,32 @@ function generateTestSchemaFilesCode({
             cs.write(
               'switch(paramType.name) {\n',
               () => {
-                for (const n of ['vector', 'set', 'optional']) {
+                for (const n of ['vector', 'set', 'optional'] as const) {
                   cs.write(`case "${n}":\n`);
                   cs.indentBlock(() => {
                     cs.write(
-                      'testValue = randomValuesFromParamMetadataType(paramType.value, typeModuleResult);\n'
+                      'testValue = randomValuesFromParamMetadataType(importPath, paramType.value, typeModuleResult);\n'
                     );
+                    switch (n) {
+                      case 'optional':
+                        cs.write(
+                          'if(crypto.randomInt(0,1) === 1) testValue = null;\n'
+                        );
+                        break;
+                      case 'set':
+                        cs.write('testValue = new Set([testValue]);\n');
+                        break;
+                      case 'vector':
+                        cs.write('testValue = [testValue];\n');
+                        break;
+                    }
                     cs.write('break;\n');
                   });
                 }
                 cs.write('case "tuple":\n');
                 cs.indentBlock(() => {
                   cs.write(
-                    'testValue = paramType.args.map(arg => randomValuesFromParamMetadataType(arg, typeModuleResult));\n'
+                    'testValue = paramType.args.map(arg => randomValuesFromParamMetadataType(importPath, arg, typeModuleResult));\n'
                   );
                   cs.write('break;\n');
                 });
@@ -130,7 +166,7 @@ function generateTestSchemaFilesCode({
               'if(paramType.type === "externalType") {\n',
               () => {
                 cs.write(
-                  'typeModuleResult = require(paramType.relativePath);\n'
+                  'typeModuleResult = require(resolveRelativeImport(importPath, paramType));\n'
                 );
               },
               '} else {\n'
@@ -149,7 +185,7 @@ function generateTestSchemaFilesCode({
               "assert.strict.ok(typeof outMetadata !== 'undefined' && typeof defaultFn === 'function');\n"
             );
             cs.write(
-              'testValue = defaultFn(Object.fromEntries(randomValuesFromMetadata(outMetadata, typeModuleResult)));\n'
+              'testValue = defaultFn(Object.fromEntries(randomValuesFromMetadata(importPath, outMetadata, typeModuleResult)));\n'
             );
             cs.write('break;\n');
           });
@@ -174,7 +210,238 @@ function generateTestSchemaFilesCode({
     '}\n'
   );
   cs.write(
-    'function randomValuesFromMetadata(metadata, typeModuleResult = null) {',
+    'function encodeParamGeneric(param) {\n',
+    () => {
+      cs.write(
+        'switch(param.name) {\n',
+        () => {
+          for (const { types, write } of [
+            {
+              types: ['int', 'int32'],
+              write: () =>
+                cs.write(
+                  's.writeInt32(crypto.randomFillSync(new Int32Array(1))[0]);\n'
+                ),
+            },
+            {
+              types: ['long'],
+              write: () =>
+                cs.write(
+                  's.writeSignedLong(crypto.randomFillSync(new BigInt64Array(1))[0].toString());\n'
+                ),
+            },
+            {
+              types: ['ulong'],
+              write: () =>
+                cs.write(
+                  's.writeUnsignedLong(crypto.randomFillSync(new BigUint64Array(1))[0].toString());\n'
+                ),
+            },
+            {
+              types: ['double'],
+              write: () =>
+                cs.write(
+                  's.writeDouble(crypto.randomFillSync(new Float64Array(1))[0]);\n'
+                ),
+            },
+            {
+              types: ['float'],
+              write: () =>
+                cs.write(
+                  's.writeDouble(crypto.randomFillSync(new Float32Array(1))[0]);\n'
+                ),
+            },
+            {
+              types: ['uint', 'uint32'],
+              write: () =>
+                cs.write(
+                  's.writeUint32(crypto.randomFillSync(new Uint32Array(1))[0]);\n'
+                ),
+            },
+            {
+              types: ['uint8'],
+              write: () =>
+                cs.write(
+                  's.writeUint8(crypto.randomFillSync(new Uint8Array(1))[0]);\n'
+                ),
+            },
+            {
+              types: ['string'],
+              write: () =>
+                cs.write(
+                  "s.writeString(crypto.randomBytes(1000).toString('hex'));\n"
+                ),
+            },
+          ]) {
+            for (const t of types) {
+              cs.write(`case "${t}":\n`);
+              cs.indentBlock(() => {
+                write();
+                cs.write('return true;\n');
+              });
+            }
+          }
+        },
+        '}\n'
+      );
+      cs.write("console.error('Unhandled generic: %s',param.name);\n");
+      cs.write('return false;\n');
+    },
+    '}\n'
+  );
+  cs.write(
+    'function encodeParamTemplate(param) {\n',
+    () => {
+      cs.write(
+        'switch(param.name) {\n',
+        () => {
+          cs.write('case "generic":\n');
+          cs.indentBlock(() => {
+            cs.write('return encodeParamGeneric(param);\n');
+          });
+          cs.write('case "map":\n');
+          cs.indentBlock(() => {
+            cs.write('s.writeUint32(1);\n');
+            cs.write('assert.strict.ok(encodeParamTemplate(param.key));\n');
+            cs.write('assert.strict.ok(encodeParamTemplate(param.value));\n');
+            cs.write('return true;\n');
+          });
+        },
+        '}\n'
+      );
+      cs.write('console.error("Failed to encode template: %s", param.name);\n');
+      cs.write('return false;\n');
+    },
+    '}\n'
+  );
+  cs.write(
+    'function encodeParam(ctx) {\n',
+    () => {
+      cs.write('const { exports, importPath, paramType } = ctx;');
+      cs.write(
+        'switch(paramType.type){\n',
+        () => {
+          for (const { name, fn } of [
+            {
+              name: 'template',
+              fn: 'encodeParamTemplate',
+            },
+            {
+              name: 'generic',
+              fn: 'encodeParamGeneric',
+            },
+          ]) {
+            cs.write(`case "${name}":\n`);
+            cs.indentBlock(() => {
+              cs.write(`return ${fn}(paramType);\n`);
+            });
+          }
+          cs.write('case "externalType":\n');
+          cs.write(
+            'case "internalType": {\n',
+            () => {
+              cs.write('let importedModule = exports;\n');
+              cs.write(
+                'if(paramType.type == "externalType") {\n',
+                () => {
+                  cs.write(
+                    'importedModule = require(resolveRelativeImport(importPath, paramType));\n'
+                  );
+                },
+                '}\n'
+              );
+              cs.write(
+                'const encodeFn = importedModule[`encode${paramType.name}`];\n'
+              );
+              cs.write(
+                'const defaultFn = importedModule[`default${paramType.name}`];\n'
+              );
+              cs.write('encodeFn(s, defaultFn());\n');
+              cs.write('return true;\n');
+            },
+            '}\n'
+          );
+          cs.write('default:\n');
+          cs.indentBlock(() => {
+            cs.write(
+              "console.error('Failed to param type: %s', paramType.type);\n"
+            );
+            cs.write('break;\n');
+          });
+        },
+        '}\n'
+      );
+      cs.write('return false;\n');
+    },
+    '}\n'
+  );
+  cs.write(
+    'function encodeUntil({importPath, metadata, exports, paramIndex}) {\n',
+    () => {
+      cs.write('s.writeInt32(metadata.id);\n');
+      cs.write(
+        'for(const paramMetadata of metadata.params.slice(0,paramIndex)){\n',
+        () => {
+          cs.write('const paramType = paramMetadata.type;\n');
+          cs.write(
+            'if(!encodeParam({importPath, exports, paramType})) {\n',
+            () => {
+              cs.write(
+                'throw new Error(`Failed to encode param: ${paramMetadata.name}`);\n'
+              );
+            },
+            '}\n'
+          );
+        },
+        '}\n'
+      );
+    },
+    '}\n'
+  );
+  cs.write(
+    'function testCodec({importPath, metadata, exports}) {\n',
+    () => {
+      cs.write('const encodeFn = exports[`encode${metadata.name}`];\n');
+      cs.write('const decodeFn = exports[`decode${metadata.name}`];\n');
+      cs.write('const { params } = metadata;\n');
+      cs.write(
+        'for(let i = 0; i < params.length; i++) {\n',
+        () => {
+          cs.write('const paramMetadata = params[i];\n');
+          cs.write('const paramType = paramMetadata.type;\n');
+          cs.write(
+            'if(paramType.type === "internalType" || paramType.type === "externalType") {\n',
+            () => {
+              cs.write('if(paramType.externalModule) continue;');
+              cs.write('s.rewind();\n');
+              cs.write(
+                'encodeUntil({ importPath, metadata, exports, paramIndex: i});\n'
+              );
+              cs.write('s.writeInt32(paramType.id * 1000);\n');
+              cs.write(
+                'const d = new Deserializer({\n',
+                () => {
+                  cs.write('textDecoder: new TextDecoder(),\n');
+                  cs.write('buffer: s.view()\n');
+                },
+                '});\n'
+              );
+              cs.write(
+                "console.log('\ttesting failure while decoding param: %s', paramMetadata.name);\n"
+              );
+              cs.write('assert.strict.equal(decodeFn(d),null);\n');
+              cs.write('continue;\n');
+            },
+            '}\n'
+          );
+        },
+        '}\n'
+      );
+    },
+    '}\n'
+  );
+  cs.write(
+    'function randomValuesFromMetadata(importPath, metadata, typeModuleResult = null) {',
     () => {
       cs.write('const result = new Map();\n');
       cs.write(
@@ -182,7 +449,7 @@ function generateTestSchemaFilesCode({
         () => {
           cs.write('const paramType = paramMetadata.type;\n');
           cs.write(
-            'const testValue = randomValuesFromParamMetadataType(paramType, typeModuleResult);\n'
+            'const testValue = randomValuesFromParamMetadataType(importPath, paramType, typeModuleResult);\n'
           );
           cs.write('result.set(paramMetadata.name,testValue);\n');
         },
@@ -213,6 +480,7 @@ function generateTestSchemaFilesCode({
     cs.write(`const ${value} = value[${value}Key];\n`);
   };
   cs.write("const assert = require('assert');\n");
+  cs.write("const path = require('path');\n");
   cs.write("const crypto = require('crypto');\n");
   cs.write("const {Serializer,Deserializer} = require('jsbuffer/codec');\n");
   cs.write(
@@ -276,6 +544,7 @@ function generateTestSchemaFilesCode({
             getFn('encodeFn', 'encode');
             getFn('decodeFn', 'decode');
             getFn('updateFn', 'update');
+            cs.write("console.log('\t-- %s',suffix);\n");
             cs.write(
               'if(updateFn){\n',
               () => {
@@ -297,11 +566,44 @@ function generateTestSchemaFilesCode({
             cs.write(
               'if(metadata) {\n',
               () => {
+                cs.write(`const importPath = "${path.resolve(rootDir, f)}";\n`);
                 cs.write(
-                  'for(const [k,v] of randomValuesFromMetadata(metadata, value)) {\n',
+                  'testCodec({importPath, exports: value, metadata, value});\n'
+                );
+                cs.write(
+                  'for(const [k,v] of randomValuesFromMetadata(importPath, metadata, value)) {\n',
                   () => {
+                    {
+                      cs.write(
+                        "console.log('\ttesting compare of param: %s', k);\n"
+                      );
+                      cs.write(
+                        'assert.strict.equal(compareFn(',
+                        () => {
+                          cs.write('updateFn(defaultFn(),{[k]: v}),\n');
+                          cs.write('defaultFn()\n');
+                        },
+                        '),false);\n'
+                      );
+                      cs.write(
+                        'assert.strict.equal(compareFn(',
+                        () => {
+                          cs.write('updateFn(defaultFn(),{[k]: v}),\n');
+                          cs.write('updateFn(defaultFn(),{[k]: v})\n');
+                        },
+                        '),true);\n'
+                      );
+                      cs.write(
+                        'assert.strict.ok(compareFn(',
+                        () => {
+                          cs.write('defaultFn(),\n');
+                          cs.write('defaultFn()\n');
+                        },
+                        '));\n'
+                      );
+                    }
                     cs.write(
-                      "console.log('\ttesting update of param: %s', k);"
+                      "console.log('\ttesting update of param: %s', k);\n"
                     );
                     cs.write(
                       'assert.strict.deepEqual(\n',
@@ -314,6 +616,13 @@ function generateTestSchemaFilesCode({
                   },
                   '}\n'
                 );
+              },
+              '}\n'
+            );
+            cs.write(
+              'if(!metadata) {\n',
+              () => {
+                cs.write('console.log(`no metadata found for: ${suffix}`);');
               },
               '}\n'
             );
@@ -346,64 +655,6 @@ function generateTestSchemaFilesCode({
               // TODO: check for exceptions when decoding parameters stuff or anything that can throw inside a predicate
             }
             // TODO: this would assume, types cannot end with `Trait`. This is at risking of not testing the updateFn function
-            // cs.write(
-            //   "const props = Object.keys(v1).filter(k => k !== '_name').map(key => ({\n",
-            //   () => {
-            //     cs.write('key,\n');
-            //     cs.write("isString: typeof v1[key] === 'string',\n");
-            //     cs.write("isNumber: typeof v1[key] === 'number',\n");
-            //   },
-            //   '})).filter(v => v.isString || v.isNumber);\n'
-            // );
-            // cs.write(
-            //   'if(updateFnKey && !/Trait$/.test(updateFnKey)) {\n',
-            //   () => {
-            //     cs.write("assert.strict.ok(typeof updateFn === 'function');\n");
-            //     cs.write(
-            //       'for(const prop of props) {\n',
-            //       () => {
-            //         for (const v of [
-            //           {
-            //             check: 'prop.isString',
-            //             type: 'string',
-            //           },
-            //           {
-            //             check: 'prop.isNumber',
-            //             type: 'number',
-            //           },
-            //         ]) {
-            //           cs.write(
-            //             `if(${v.check}) {\n`,
-            //             () => {
-            //               const randomString =
-            //                 v.type === 'string'
-            //                   ? `"${crypto.randomBytes(32).toString('base64')}"`
-            //                   : crypto.randomInt(1000, 2000);
-            //               cs.write(
-            //                 `assert.strict.notEqual(updateFn(v1,{[prop.key]:${randomString}}),v1);\n`
-            //               );
-            //               cs.write(
-            //                 `assert.strict.deepEqual(updateFn(v1,{[prop.key]:${randomString}}),defaultFn({[prop.key]:${randomString}}));\n`
-            //               );
-            //             },
-            //             '}\n'
-            //           );
-            //         }
-            //         cs.write(
-            //           'assert.strict.equal(updateFn(v1,{[prop.key]:v1[prop.key]}),v1);\n'
-            //         );
-            //       },
-            //       '}\n'
-            //     );
-
-            //     /**
-            //      * test updateFn
-            //      */
-            //     cs.write('assert.strict.equal(updateFn(v1,defaultFn()),v1);\n');
-            //     cs.write("console.log('\t%s: ok',updateFn.name);\n");
-            //   },
-            //   '}\n'
-            // );
             /**
              * test defaultFn
              */
@@ -437,7 +688,16 @@ export async function generateWithVirtualFs({
   paths: Record<string, string>;
 }) {
   const outDirBaseName = '__compiled__';
-  const rootDir = await fs.promises.mkdtemp('/tmp/jsbuffer-');
+  const tmpFolder = path.resolve(__dirname, '../node_modules/.cache/jsbuffer');
+  try {
+    await fs.promises.access(tmpFolder, fs.constants.W_OK | fs.constants.R_OK);
+    assert.strict.ok((await fs.promises.stat(tmpFolder)).isDirectory());
+  } catch (reason) {
+    await fs.promises.mkdir(tmpFolder);
+  }
+  const rootDir = await fs.promises.mkdtemp(
+    path.resolve(tmpFolder, 'jsbuffer-')
+  );
   const outDir = path.resolve(rootDir, outDirBaseName);
 
   const runCommand = (command: string, args: string[]) =>
@@ -495,6 +755,13 @@ export async function generateWithVirtualFs({
       {
         outDir: path.relative(rootDir, outDir),
         mainFile: path.relative(rootDir, path.resolve(rootDir, mainFile)),
+      },
+      null,
+      2
+    ),
+    '.nycrc': JSON.stringify(
+      {
+        all: true,
       },
       null,
       2

--- a/out/User.ts
+++ b/out/User.ts
@@ -93,14 +93,10 @@ export const userMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
-            value: {
-              type: 'generic',
-              value: 'string',
-            },
-          },
-        ],
+        value: {
+          type: 'generic',
+          value: 'string',
+        },
       },
     },
   ],
@@ -310,30 +306,18 @@ export const testMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
+        value: {
+          type: 'template',
+          name: 'vector',
+          value: {
+            type: 'template',
+            name: 'optional',
             value: {
-              type: 'template',
-              name: 'vector',
-              params: [
-                {
-                  value: {
-                    type: 'template',
-                    name: 'optional',
-                    params: [
-                      {
-                        value: {
-                          type: 'generic',
-                          value: 'string',
-                        },
-                      },
-                    ],
-                  },
-                },
-              ],
+              type: 'generic',
+              value: 'string',
             },
           },
-        ],
+        },
       },
     },
   ],

--- a/out/conversation/index.ts
+++ b/out/conversation/index.ts
@@ -132,15 +132,11 @@ export const ConversationsMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
-            value: {
-              type: 'internalType',
-              kind: 'type',
-              name: 'Conversation',
-            },
-          },
-        ],
+        value: {
+          type: 'internalType',
+          kind: 'type',
+          name: 'Conversation',
+        },
       },
     },
   ],

--- a/out/message.ts
+++ b/out/message.ts
@@ -88,15 +88,11 @@ export const MessagesMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
-            value: {
-              type: 'internalType',
-              kind: 'type',
-              name: 'Message',
-            },
-          },
-        ],
+        value: {
+          type: 'internalType',
+          kind: 'type',
+          name: 'Message',
+        },
       },
     },
   ],

--- a/out/schema.ts
+++ b/out/schema.ts
@@ -14,18 +14,14 @@ export const testMapMetadata = {
       type: {
         type: 'template',
         name: 'map',
-        params: [
-          {
-            key: {
-              type: 'generic',
-              value: 'string',
-            },
-            value: {
-              type: 'generic',
-              value: 'string',
-            },
-          },
-        ],
+        key: {
+          type: 'generic',
+          value: 'string',
+        },
+        value: {
+          type: 'generic',
+          value: 'string',
+        },
       },
     },
   ],
@@ -127,26 +123,18 @@ export const testMap2Metadata = {
       type: {
         type: 'template',
         name: 'map',
-        params: [
-          {
-            key: {
-              type: 'template',
-              name: 'optional',
-              params: [
-                {
-                  value: {
-                    type: 'generic',
-                    value: 'string',
-                  },
-                },
-              ],
-            },
-            value: {
-              type: 'generic',
-              value: 'string',
-            },
+        key: {
+          type: 'template',
+          name: 'optional',
+          value: {
+            type: 'generic',
+            value: 'string',
           },
-        ],
+        },
+        value: {
+          type: 'generic',
+          value: 'string',
+        },
       },
     },
     {
@@ -154,52 +142,36 @@ export const testMap2Metadata = {
       type: {
         type: 'template',
         name: 'map',
-        params: [
-          {
-            key: {
-              type: 'template',
-              name: 'optional',
-              params: [
-                {
-                  value: {
-                    type: 'generic',
-                    value: 'string',
-                  },
-                },
-              ],
-            },
-            value: {
-              type: 'template',
-              name: 'tuple',
-              params: [
-                {
-                  args: [
-                    {
-                      type: 'generic',
-                      value: 'string',
-                    },
-                    {
-                      type: 'template',
-                      name: 'map',
-                      params: [
-                        {
-                          key: {
-                            type: 'generic',
-                            value: 'int',
-                          },
-                          value: {
-                            type: 'generic',
-                            value: 'int',
-                          },
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
+        key: {
+          type: 'template',
+          name: 'optional',
+          value: {
+            type: 'generic',
+            value: 'string',
           },
-        ],
+        },
+        value: {
+          type: 'template',
+          name: 'tuple',
+          args: [
+            {
+              type: 'generic',
+              value: 'string',
+            },
+            {
+              type: 'template',
+              name: 'map',
+              key: {
+                type: 'generic',
+                value: 'int',
+              },
+              value: {
+                type: 'generic',
+                value: 'int',
+              },
+            },
+          ],
+        },
       },
     },
   ],
@@ -424,19 +396,15 @@ export const testMap3Metadata = {
       type: {
         type: 'template',
         name: 'map',
-        params: [
-          {
-            key: {
-              type: 'internalType',
-              kind: 'type',
-              name: 'testMap2',
-            },
-            value: {
-              type: 'generic',
-              value: 'string',
-            },
-          },
-        ],
+        key: {
+          type: 'internalType',
+          kind: 'type',
+          name: 'testMap2',
+        },
+        value: {
+          type: 'generic',
+          value: 'string',
+        },
       },
     },
   ],
@@ -539,14 +507,10 @@ export const testSetMetadata = {
       type: {
         type: 'template',
         name: 'set',
-        params: [
-          {
-            value: {
-              type: 'generic',
-              value: 'string',
-            },
-          },
-        ],
+        value: {
+          type: 'generic',
+          value: 'string',
+        },
       },
     },
     {
@@ -554,14 +518,10 @@ export const testSetMetadata = {
       type: {
         type: 'template',
         name: 'set',
-        params: [
-          {
-            value: {
-              type: 'generic',
-              value: 'int',
-            },
-          },
-        ],
+        value: {
+          type: 'generic',
+          value: 'int',
+        },
       },
     },
   ],
@@ -706,14 +666,10 @@ export const testSet2Metadata = {
       type: {
         type: 'template',
         name: 'set',
-        params: [
-          {
-            value: {
-              type: 'generic',
-              value: 'string',
-            },
-          },
-        ],
+        value: {
+          type: 'generic',
+          value: 'string',
+        },
       },
     },
     {
@@ -721,26 +677,18 @@ export const testSet2Metadata = {
       type: {
         type: 'template',
         name: 'set',
-        params: [
-          {
-            value: {
-              type: 'template',
-              name: 'map',
-              params: [
-                {
-                  key: {
-                    type: 'generic',
-                    value: 'string',
-                  },
-                  value: {
-                    type: 'generic',
-                    value: 'string',
-                  },
-                },
-              ],
-            },
+        value: {
+          type: 'template',
+          name: 'map',
+          key: {
+            type: 'generic',
+            value: 'string',
           },
-        ],
+          value: {
+            type: 'generic',
+            value: 'string',
+          },
+        },
       },
     },
     {
@@ -748,28 +696,20 @@ export const testSet2Metadata = {
       type: {
         type: 'template',
         name: 'set',
-        params: [
-          {
-            value: {
-              type: 'template',
-              name: 'tuple',
-              params: [
-                {
-                  args: [
-                    {
-                      type: 'generic',
-                      value: 'int',
-                    },
-                    {
-                      type: 'generic',
-                      value: 'int',
-                    },
-                  ],
-                },
-              ],
+        value: {
+          type: 'template',
+          name: 'tuple',
+          args: [
+            {
+              type: 'generic',
+              value: 'int',
             },
-          },
-        ],
+            {
+              type: 'generic',
+              value: 'int',
+            },
+          ],
+        },
       },
     },
   ],
@@ -1163,15 +1103,11 @@ export const UsersMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
-            value: {
-              name: 'User',
-              type: 'externalType',
-              relativePath: './User',
-            },
-          },
-        ],
+        value: {
+          name: 'User',
+          type: 'externalType',
+          relativePath: './User',
+        },
       },
     },
   ],
@@ -1424,15 +1360,11 @@ export const PostsMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
-            value: {
-              type: 'internalType',
-              kind: 'type',
-              name: 'Post',
-            },
-          },
-        ],
+        value: {
+          type: 'internalType',
+          kind: 'type',
+          name: 'Post',
+        },
       },
     },
   ],
@@ -1774,14 +1706,10 @@ export const ShouldSupportSeveralSequentialVectorParamsMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
-            value: {
-              type: 'generic',
-              value: 'int',
-            },
-          },
-        ],
+        value: {
+          type: 'generic',
+          value: 'int',
+        },
       },
     },
     {
@@ -1789,14 +1717,10 @@ export const ShouldSupportSeveralSequentialVectorParamsMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
-            value: {
-              type: 'generic',
-              value: 'double',
-            },
-          },
-        ],
+        value: {
+          type: 'generic',
+          value: 'double',
+        },
       },
     },
     {
@@ -1804,14 +1728,10 @@ export const ShouldSupportSeveralSequentialVectorParamsMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
-            value: {
-              type: 'generic',
-              value: 'string',
-            },
-          },
-        ],
+        value: {
+          type: 'generic',
+          value: 'string',
+        },
       },
     },
     {
@@ -1819,14 +1739,10 @@ export const ShouldSupportSeveralSequentialVectorParamsMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
-            value: {
-              type: 'generic',
-              value: 'float',
-            },
-          },
-        ],
+        value: {
+          type: 'generic',
+          value: 'float',
+        },
       },
     },
     {
@@ -1834,14 +1750,10 @@ export const ShouldSupportSeveralSequentialVectorParamsMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
-            value: {
-              type: 'generic',
-              value: 'uint32',
-            },
-          },
-        ],
+        value: {
+          type: 'generic',
+          value: 'uint32',
+        },
       },
     },
     {
@@ -1849,30 +1761,18 @@ export const ShouldSupportSeveralSequentialVectorParamsMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
+        value: {
+          type: 'template',
+          name: 'optional',
+          value: {
+            type: 'template',
+            name: 'vector',
             value: {
-              type: 'template',
-              name: 'optional',
-              params: [
-                {
-                  value: {
-                    type: 'template',
-                    name: 'vector',
-                    params: [
-                      {
-                        value: {
-                          type: 'generic',
-                          value: 'uint32',
-                        },
-                      },
-                    ],
-                  },
-                },
-              ],
+              type: 'generic',
+              value: 'uint32',
             },
           },
-        ],
+        },
       },
     },
     {
@@ -1880,46 +1780,34 @@ export const ShouldSupportSeveralSequentialVectorParamsMetadata = {
       type: {
         type: 'template',
         name: 'tuple',
-        params: [
+        args: [
           {
-            args: [
-              {
-                type: 'generic',
-                value: 'int',
-              },
-              {
-                type: 'generic',
-                value: 'float',
-              },
-              {
-                type: 'generic',
-                value: 'double',
-              },
-              {
-                type: 'template',
-                name: 'vector',
-                params: [
-                  {
-                    value: {
-                      type: 'generic',
-                      value: 'uint32',
-                    },
-                  },
-                ],
-              },
-              {
-                type: 'template',
-                name: 'optional',
-                params: [
-                  {
-                    value: {
-                      type: 'generic',
-                      value: 'string',
-                    },
-                  },
-                ],
-              },
-            ],
+            type: 'generic',
+            value: 'int',
+          },
+          {
+            type: 'generic',
+            value: 'float',
+          },
+          {
+            type: 'generic',
+            value: 'double',
+          },
+          {
+            type: 'template',
+            name: 'vector',
+            value: {
+              type: 'generic',
+              value: 'uint32',
+            },
+          },
+          {
+            type: 'template',
+            name: 'optional',
+            value: {
+              type: 'generic',
+              value: 'string',
+            },
           },
         ],
       },
@@ -2384,46 +2272,34 @@ export const simpleTupleTestMetadata = {
       type: {
         type: 'template',
         name: 'tuple',
-        params: [
+        args: [
           {
-            args: [
-              {
-                type: 'generic',
-                value: 'int',
-              },
-              {
-                type: 'generic',
-                value: 'float',
-              },
-              {
-                type: 'generic',
-                value: 'double',
-              },
-              {
-                type: 'template',
-                name: 'vector',
-                params: [
-                  {
-                    value: {
-                      type: 'generic',
-                      value: 'uint32',
-                    },
-                  },
-                ],
-              },
-              {
-                type: 'template',
-                name: 'optional',
-                params: [
-                  {
-                    value: {
-                      type: 'generic',
-                      value: 'string',
-                    },
-                  },
-                ],
-              },
-            ],
+            type: 'generic',
+            value: 'int',
+          },
+          {
+            type: 'generic',
+            value: 'float',
+          },
+          {
+            type: 'generic',
+            value: 'double',
+          },
+          {
+            type: 'template',
+            name: 'vector',
+            value: {
+              type: 'generic',
+              value: 'uint32',
+            },
+          },
+          {
+            type: 'template',
+            name: 'optional',
+            value: {
+              type: 'generic',
+              value: 'string',
+            },
           },
         ],
       },
@@ -2433,56 +2309,40 @@ export const simpleTupleTestMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
-            value: {
-              type: 'template',
-              name: 'tuple',
-              params: [
-                {
-                  args: [
-                    {
-                      type: 'generic',
-                      value: 'int',
-                    },
-                    {
-                      type: 'generic',
-                      value: 'float',
-                    },
-                    {
-                      type: 'generic',
-                      value: 'double',
-                    },
-                    {
-                      type: 'template',
-                      name: 'vector',
-                      params: [
-                        {
-                          value: {
-                            type: 'generic',
-                            value: 'uint32',
-                          },
-                        },
-                      ],
-                    },
-                    {
-                      type: 'template',
-                      name: 'optional',
-                      params: [
-                        {
-                          value: {
-                            type: 'generic',
-                            value: 'string',
-                          },
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
+        value: {
+          type: 'template',
+          name: 'tuple',
+          args: [
+            {
+              type: 'generic',
+              value: 'int',
             },
-          },
-        ],
+            {
+              type: 'generic',
+              value: 'float',
+            },
+            {
+              type: 'generic',
+              value: 'double',
+            },
+            {
+              type: 'template',
+              name: 'vector',
+              value: {
+                type: 'generic',
+                value: 'uint32',
+              },
+            },
+            {
+              type: 'template',
+              name: 'optional',
+              value: {
+                type: 'generic',
+                value: 'string',
+              },
+            },
+          ],
+        },
       },
     },
   ],
@@ -3029,14 +2889,10 @@ export const nullTerminatedStringListMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
-            value: {
-              type: 'generic',
-              value: 'null_terminated_string',
-            },
-          },
-        ],
+        value: {
+          type: 'generic',
+          value: 'null_terminated_string',
+        },
       },
     },
   ],
@@ -3142,14 +2998,10 @@ export const normalStringListMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
-            value: {
-              type: 'generic',
-              value: 'string',
-            },
-          },
-        ],
+        value: {
+          type: 'generic',
+          value: 'string',
+        },
       },
     },
   ],
@@ -3255,8 +3107,18 @@ export const boolAndTupleMetadata = {
       type: {
         type: 'template',
         name: 'tuple',
-        params: [
+        args: [
           {
+            type: 'generic',
+            value: 'bool',
+          },
+          {
+            type: 'generic',
+            value: 'bool',
+          },
+          {
+            type: 'template',
+            name: 'tuple',
             args: [
               {
                 type: 'generic',
@@ -3265,24 +3127,6 @@ export const boolAndTupleMetadata = {
               {
                 type: 'generic',
                 value: 'bool',
-              },
-              {
-                type: 'template',
-                name: 'tuple',
-                params: [
-                  {
-                    args: [
-                      {
-                        type: 'generic',
-                        value: 'bool',
-                      },
-                      {
-                        type: 'generic',
-                        value: 'bool',
-                      },
-                    ],
-                  },
-                ],
               },
             ],
           },

--- a/out/tupleTest2.ts
+++ b/out/tupleTest2.ts
@@ -164,15 +164,11 @@ export const postMetadata = {
       type: {
         type: 'template',
         name: 'vector',
-        params: [
-          {
-            value: {
-              type: 'internalType',
-              kind: 'type',
-              name: 'comment',
-            },
-          },
-        ],
+        value: {
+          type: 'internalType',
+          kind: 'type',
+          name: 'comment',
+        },
       },
     },
   ],
@@ -470,59 +466,43 @@ export const tupleTestMetadata = {
       type: {
         type: 'template',
         name: 'tuple',
-        params: [
+        args: [
           {
-            args: [
-              {
-                type: 'internalType',
-                kind: 'type',
-                name: 'user',
-              },
-              {
-                type: 'internalType',
-                kind: 'type',
-                name: 'post',
-              },
-              {
+            type: 'internalType',
+            kind: 'type',
+            name: 'user',
+          },
+          {
+            type: 'internalType',
+            kind: 'type',
+            name: 'post',
+          },
+          {
+            type: 'internalType',
+            kind: 'type',
+            name: 'comment',
+          },
+          {
+            type: 'template',
+            name: 'vector',
+            value: {
+              type: 'internalType',
+              kind: 'type',
+              name: 'comment',
+            },
+          },
+          {
+            type: 'template',
+            name: 'vector',
+            value: {
+              type: 'template',
+              name: 'optional',
+              value: {
                 type: 'internalType',
                 kind: 'type',
                 name: 'comment',
               },
-              {
-                type: 'template',
-                name: 'vector',
-                params: [
-                  {
-                    value: {
-                      type: 'internalType',
-                      kind: 'type',
-                      name: 'comment',
-                    },
-                  },
-                ],
-              },
-              {
-                type: 'template',
-                name: 'vector',
-                params: [
-                  {
-                    value: {
-                      type: 'template',
-                      name: 'optional',
-                      params: [
-                        {
-                          value: {
-                            type: 'internalType',
-                            kind: 'type',
-                            name: 'comment',
-                          },
-                        },
-                      ],
-                    },
-                  },
-                ],
-              },
-            ],
+            },
           },
         ],
       },
@@ -737,53 +717,11 @@ export const tupleTupleTestMetadata = {
       type: {
         type: 'template',
         name: 'tuple',
-        params: [
+        args: [
           {
+            type: 'template',
+            name: 'tuple',
             args: [
-              {
-                type: 'template',
-                name: 'tuple',
-                params: [
-                  {
-                    args: [
-                      {
-                        type: 'generic',
-                        value: 'int',
-                      },
-                      {
-                        type: 'generic',
-                        value: 'string',
-                      },
-                      {
-                        type: 'template',
-                        name: 'vector',
-                        params: [
-                          {
-                            value: {
-                              type: 'template',
-                              name: 'tuple',
-                              params: [
-                                {
-                                  args: [
-                                    {
-                                      type: 'generic',
-                                      value: 'string',
-                                    },
-                                    {
-                                      type: 'generic',
-                                      value: 'int',
-                                    },
-                                  ],
-                                },
-                              ],
-                            },
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              },
               {
                 type: 'generic',
                 value: 'int',
@@ -793,10 +731,36 @@ export const tupleTupleTestMetadata = {
                 value: 'string',
               },
               {
-                type: 'generic',
-                value: 'double',
+                type: 'template',
+                name: 'vector',
+                value: {
+                  type: 'template',
+                  name: 'tuple',
+                  args: [
+                    {
+                      type: 'generic',
+                      value: 'string',
+                    },
+                    {
+                      type: 'generic',
+                      value: 'int',
+                    },
+                  ],
+                },
               },
             ],
+          },
+          {
+            type: 'generic',
+            value: 'int',
+          },
+          {
+            type: 'generic',
+            value: 'string',
+          },
+          {
+            type: 'generic',
+            value: 'double',
           },
         ],
       },
@@ -991,42 +955,30 @@ export const superTupleTupleTestMetadata = {
       type: {
         type: 'template',
         name: 'tuple',
-        params: [
+        args: [
           {
+            type: 'template',
+            name: 'tuple',
             args: [
               {
                 type: 'template',
                 name: 'tuple',
-                params: [
+                args: [
                   {
-                    args: [
-                      {
-                        type: 'template',
-                        name: 'tuple',
-                        params: [
-                          {
-                            args: [
-                              {
-                                type: 'generic',
-                                value: 'int',
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                      {
-                        type: 'generic',
-                        value: 'int',
-                      },
-                    ],
+                    type: 'generic',
+                    value: 'int',
                   },
                 ],
               },
               {
                 type: 'generic',
-                value: 'double',
+                value: 'int',
               },
             ],
+          },
+          {
+            type: 'generic',
+            value: 'double',
           },
         ],
       },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "name": "jsbuffer",
   "license": "MIT",
-  "version": "0.0.66",
+  "version": "0.0.69",
   "main": "./src/index.js",
   "bin": {
     "jsbuffer": "./cli/index.js"

--- a/test/FileGenerator.ts
+++ b/test/FileGenerator.ts
@@ -28,7 +28,9 @@ suite.test('it should be able to test deep types', async () => {
       },
       paths: {
         main: [
-          'export type F { int value; }',
+          'export type H { int value; tuple<int,int> value2; }',
+          'export type G { vector<H> value; }',
+          'export type F { G value; }',
           'export type E { F value; }',
           'export type D { E value; }',
           'export type C { D value; }',

--- a/test/FileGenerator.ts
+++ b/test/FileGenerator.ts
@@ -20,6 +20,27 @@ function checkException(fn: () => Promise<void>) {
   };
 }
 
+suite.test('it should be able to test deep types', async () => {
+  await (
+    await generateWithVirtualFs({
+      packageInfo: {
+        name: 'test-schema',
+      },
+      paths: {
+        main: [
+          'export type F { int value; }',
+          'export type E { F value; }',
+          'export type D { E value; }',
+          'export type C { D value; }',
+          'export type B { C value; }',
+          'export type A { B value; }',
+        ].join('\n'),
+      },
+      mainFile: 'main',
+    })
+  ).test();
+});
+
 suite.test(
   'it should test all sorts of generic parameters',
   checkException(async () => {


### PR DESCRIPTION
Something that is a must to keep noted about these generated tests, is that these can be expanded to be generated in a more adaptive way. For example:

```ts
await testSchema(path.resolve(__dirname,'../schema-source-code/jsbufferconfig.json'))
```

Not sure how much value we can put into this, but these are tests to test the generated code, so maybe we can say it's good.